### PR TITLE
Rename extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ff-goto
+# goto-select
 
 ## What it does
 

--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const extId = "ff-goto";
+const extId = "goto-select";
 let link;
 
 browser.menus.create({

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Firefox Goto",
+  "name": "Goto Select",
   "description": "Adds a context menu item that opens the selected text as a link in a new tab",
   "version": "1.0",
 


### PR DESCRIPTION
Firefox shouldn't be used directly in the name to avoid being 'official'.